### PR TITLE
Fixed curl command in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,5 +17,5 @@ __ https://brew.sh/
 
 Manually::
 
-    $ curl https://raw.githubusercontent.com/wolever/git-blast/master/git-blast -O /usr/local/bin/git-blast
+    $ curl https://raw.githubusercontent.com/wolever/git-blast/master/git-blast -o /usr/local/bin/git-blast
     $ chmod +x /usr/local/bin/git-blast


### PR DESCRIPTION
Use lowercase ``-o`` instead of ``-O``.

At least on my Linux system, it should be in lowercase. Capital O has a different meaning.